### PR TITLE
Dropdown list fix for current Firefox.

### DIFF
--- a/dojo-release/webcat/DropDownList.js
+++ b/dojo-release/webcat/DropDownList.js
@@ -180,7 +180,7 @@ webcat.dropDownList.hideDropDown = function(event, dropDownId, menuId, force)
     else
     {
         var reltg = (event.relatedTarget) ? event.relatedTarget : event.toElement;
-        stayOpen = webcat.dropDownList._isNodeInListOrMenu(reltg);
+        stayOpen = reltg && webcat.dropDownList._isNodeInListOrMenu(reltg);
     }
 
     if (force)


### PR DESCRIPTION
In Firefox 71, the dropdown lists (with semesters, courses, etc.) don't work anymore - clicking on items results in an exception. This patch is a quick-and-dirty fix for this problem.